### PR TITLE
Fixed typographical error, changed adminstrator to administrator in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ argument and the `configure` checks are still failing, you can peruse
 the file `config.log`, created by `configure`, for the particular
 error that led the tool to fail. Sometimes unrelated problems can show
 up in this phase of the configuration process. If you still have
-trouble, consult your local system adminstrator (with complete
+trouble, consult your local system administrator (with complete
 contextual information) or the miriad-python developers.
 
 For thorough but generic instructions on running the `configure`


### PR DESCRIPTION
@pkgw, I've corrected a typographical error in the documentation of the [miriad-python](https://github.com/pkgw/miriad-python) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
